### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,30 +9,23 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [7.4, 8.0, 8.1, 8.2]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
         dependency-version: [prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ~/.composer/cache/files
-          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+        uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: pcov
 
       - name: Install dependencies
-        run: |
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+        uses: ramsey/composer-install@v3
 
       - name: Execute tests
         run: vendor/bin/phpunit --coverage-text

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -26,7 +26,7 @@ class Factory
     private HandlerStack $handler;
     public array $history = [];
 
-    public function __construct(bool $fakeRequests, LoggerInterface $logger = null)
+    public function __construct(bool $fakeRequests, ?LoggerInterface $logger = null)
     {
         $this->fakeRequests = $fakeRequests;
         $this->logger = $logger;


### PR DESCRIPTION
Fixes following deprecation:
```
Sofa\HttpClient\Factory::__construct(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/sofa/http-client/src/Factory.php on line 29
```